### PR TITLE
chore: Fix GOPRIVATE in release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,6 @@ project_name: demo-rest
 builds:
   - env:
       - CGO_ENABLED=0
-      - GOPRIVATE=github.com/cerbos/*
     goos:
       - linux
       - darwin


### PR DESCRIPTION
Remove the `GOPRIVATE` config now that Cerbos is public.

Signed-off-by: Charith Ellawala <charith.ellawala@gmail.com>