### PR TITLE
chore: Retrieve latest cerbos version from github releases

### DIFF
--- a/cerbos/start_server.sh
+++ b/cerbos/start_server.sh
@@ -2,9 +2,10 @@
 
 set -euo pipefail
 
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/cerbos/cerbos/releases/latest" | jq -r .tag_name)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_IMG=${CONTAINER_IMG:-"ghcr.io/cerbos/cerbos"}
-CONTAINER_TAG=${CONTAINER_TAG:-"0.9.0"}
+CONTAINER_TAG=${CONTAINER_TAG:-"${LATEST_VERSION:1}"}
 
 docker run -i -t -p 3592:3592 -p 3593:3593 \
   -v ${SCRIPT_DIR}/policies:/policies \


### PR DESCRIPTION
Signed-off-by: Oğuzhan D <oguzhandurgun95@gmail.com>

#### Description

Retrieves the latest release from GitHub API to use in `start_server.sh`.

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
